### PR TITLE
Add exec modes, handle standard and restart

### DIFF
--- a/src/modules/misc/utils.py
+++ b/src/modules/misc/utils.py
@@ -5,6 +5,20 @@ from socket import gethostname
 from typing import Tuple
 
 
+def get_exec_modes(cli_options: dict):
+    exec_modes = ["dry", "verify", "restart"]
+    modes = []
+
+    for mode in exec_modes:
+        if cli_options.get(mode, False):
+            modes.append(mode)
+
+    if not modes:
+        modes.append("standard")
+
+    return ", ".join(modes).strip(", ")
+
+
 class InitParams:
 
     def __init__(self):


### PR DESCRIPTION
Modes:
- [ ] standard
- [ ] restart
- [ ] mount-only
- [ ] unmount-only
- [ ] container(device)-check (with -y/-n presets for automated continuation)
- [ ] verification-only
- [ ] no-verification