### PR TITLE
Allow debug argument undefined in add_console_handler

### DIFF
--- a/src/modules/outputs/loggers.py
+++ b/src/modules/outputs/loggers.py
@@ -31,7 +31,7 @@ class Loggers:
         handler = logging.StreamHandler()
         handler.setFormatter(ColourFormatter(self.console_fmt))
 
-        if not self.options["debug"]:
+        if self.options.get("debug") is not True:
             handler.setLevel(logging.INFO)
 
         self.logger.addHandler(handler)


### PR DESCRIPTION
Empty cli_options is useful for unit testing classes that init with cli_options.

fix(logging): bb74c13743996f86cd632e71d6b82f467016a739