### PR TITLE
Add oSError exception in InitParams.get_call_id()

### DIFF
--- a/src/modules/misc/utils.py
+++ b/src/modules/misc/utils.py
@@ -24,6 +24,6 @@ class InitParams:
         try:
             user = getpwnam(getlogin())
         # Detected on Ubuntu 20.04 LTS (GNU/Linux 5.10.16.3-microsoft-standard-WSL2 x86_64)
-        except FileNotFoundError:
+        except (FileNotFoundError, OSError):
             user = getpwuid(getuid())
         return user.pw_uid, user.pw_gid, user.pw_name

--- a/tests/configs/aspell_exceptions
+++ b/tests/configs/aspell_exceptions
@@ -100,6 +100,7 @@ NONINFRINGEMENT
 noqa
 nosec
 optparse
+OSError
 OSI
 overgeneral
 param


### PR DESCRIPTION
Add oSError exception in InitParams.get_call_id() to fix getuid issue on WSL